### PR TITLE
Correctly handle dup() failure in Parcel::readNativeHandle

### DIFF
--- a/libs/binder/Parcel.cpp
+++ b/libs/binder/Parcel.cpp
@@ -1230,7 +1230,13 @@ native_handle* Parcel::readNativeHandle() const
 
     for (int i=0 ; err==NO_ERROR && i<numFds ; i++) {
         h->data[i] = dup(readFileDescriptor());
-        if (h->data[i] < 0) err = BAD_VALUE;
+        if (h->data[i] < 0) {
+            for (int j = 0; j < i; j++) {
+                close(h->data[j]);
+            }
+            native_handle_delete(h);
+            return 0;
+        }
     }
     err = read(h->data + numFds, sizeof(int)*numInts);
     if (err != NO_ERROR) {


### PR DESCRIPTION
bail out if dup() fails, instead of creating an invalid native_handle_t

Bug: 28395952
CYNGNOS-3020

Change-Id: Ia1a6198c0f45165b9c6a55a803e5f64d8afa0572
(cherry picked from commit 1de7966c72981aebc3c7f9978ab129678ac89258)
